### PR TITLE
Exclude samples from the builder

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -8,6 +8,7 @@ on:
     paths-ignore:
       - 'setup.py'
       - '.bumpversion.cfg'
+      - 'samples/'
 jobs:
  build:
     runs-on: ubuntu-latest

--- a/samples/flask/requirements.txt
+++ b/samples/flask/requirements.txt
@@ -1,2 +1,1 @@
-Flask==1.1.2
-python-jose
+asgardeo-auth-python-sdk


### PR DESCRIPTION
Excluding the samples build since the changes to the samples will bump the SDK version.
- Samples build version will be added once it has been discussed
- Removing the unnecessary requirements from the samples since asgardeo-auth-python-sdk includes all